### PR TITLE
Updates Playlists page to look for all playlists from owner

### DIFF
--- a/src/pages/PlaylistManagementPage/PlaylistManagementPage.js
+++ b/src/pages/PlaylistManagementPage/PlaylistManagementPage.js
@@ -10,8 +10,7 @@ const PlaylistManagementPage = (props) => {
 
   useEffect(() => {
     Promise.all([
-      //axios.get(`${process.env.REACT_APP_API_BASE_URL}/playlist`, {withCredentials: true}),
-      axios.get(`${process.env.REACT_APP_API_BASE_URL}/me/playlist?collaborative=true&&mine=true`, {
+      axios.get(`${process.env.REACT_APP_API_BASE_URL}/me/playlist?mine=true`, {
         withCredentials: true,
       }),
     ])


### PR DESCRIPTION
This is a workaround due to Spotify messing up with playlist flags in their back-end which, in turn, makes the API we consume to send playlist list without newly created playlists